### PR TITLE
Replace BroadcastChannel with postMessage

### DIFF
--- a/ANLEITUNG.md
+++ b/ANLEITUNG.md
@@ -2,7 +2,7 @@
 
 ## Funktionsweise
 
-Die Extension nutzt ein **Side Panel** für persistente Bedienung und verwendet BroadcastChannel-Kommunikation, um CSP-Probleme zu umgehen.
+Die Extension nutzt ein **Side Panel** für persistente Bedienung und verwendet postMessage-Kommunikation, um CSP-Probleme zu umgehen.
 
 ## Schritt-für-Schritt Anleitung
 
@@ -92,4 +92,4 @@ Die Extension nutzt ein **Side Panel** für persistente Bedienung und verwendet 
 
 ## CSP-Problem gelöst
 
-Die Extension injiziert keinen Code direkt, sondern verwendet BroadcastChannel für sichere Kommunikation zwischen Extension und Konsolen-Code.
+Die Extension injiziert keinen Code direkt, sondern verwendet postMessage für sichere Kommunikation zwischen Extension und Konsolen-Code.

--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ Viele Spiele liefern strenge CSP‑Header. Daher wird der Scanner nicht automati
 Side Panel  ←→  Service Worker
       ↑                     ↓
    Content Script ←→ Scanner (Main World)
-                   (BroadcastChannel)
+                   (postMessage)
 ```
 
 - **Manifest V3** mit Service‑Worker
-- **BroadcastChannel** statt localStorage‑Polling
+- **postMessage** statt localStorage‑Polling
 - **Scanner** läuft im Haupt‑Kontext → Vollzugriff ohne CSP‑Probleme
 - **Service-Worker-Lebenszeit** – Chrome hält ihn am Leben, solange das Side Panel offen ist. In Firefox übernimmt die Sidebar diese Rolle. Für geplante Auto-Freeze-Features können `chrome.alarms` oder `offscreenDocuments` genutzt werden.
 


### PR DESCRIPTION
## Summary
- update the architecture diagram to use postMessage
- switch documentation wording from BroadcastChannel to postMessage

## Testing
- `npm test` *(fails: Cannot find module '../../src/popup/scanner-code.js')*

------
https://chatgpt.com/codex/tasks/task_e_684429617160832098e6aca9fa9e1dbb