### PR TITLE
Fix chrome cleanup in tests

### DIFF
--- a/tests/unit/favorites.domain.test.js
+++ b/tests/unit/favorites.domain.test.js
@@ -17,6 +17,10 @@ describe("domain isolated favorites", () => {
     localStorage.clear();
   });
 
+  afterEach(() => {
+    delete globalThis.chrome;
+  });
+
   test("loads favorites for the current domain only", async () => {
     const favsA = { 1: { id: "1", name: "favA", path: "a", value: 1 } };
     const favsB = { 2: { id: "2", name: "favB", path: "b", value: 2 } };

--- a/tests/unit/favorites.test.js
+++ b/tests/unit/favorites.test.js
@@ -7,6 +7,10 @@ import {
   renameFavorite,
 } from "../../src/popup/favorites.js";
 
+afterEach(() => {
+  delete globalThis.chrome;
+});
+
 describe("parsePath", () => {
   test("parses dot notation paths", () => {
     expect(parsePath("foo.bar.baz")).toEqual(["foo", "bar", "baz"]);

--- a/tests/unit/service-worker.test.js
+++ b/tests/unit/service-worker.test.js
@@ -2,6 +2,10 @@
 import { jest } from "@jest/globals";
 
 describe("service worker panel behavior", () => {
+  afterEach(() => {
+    delete globalThis.chrome;
+  });
+
   describe("Chrome side panel", () => {
     beforeEach(() => {
       globalThis.chrome = {

--- a/tests/unit/storage-tools.test.js
+++ b/tests/unit/storage-tools.test.js
@@ -10,12 +10,7 @@ jest.mock("../../src/popup/messages.js", () => ({
   showSuccess: jest.fn(),
 }));
 
-// Mock chrome API
-globalThis.chrome = {
-  tabs: {
-    query: jest.fn(),
-  },
-};
+// chrome API will be mocked in beforeEach
 
 // Mock URL and Blob APIs
 globalThis.URL = class {
@@ -46,9 +41,17 @@ import { send } from "../../src/popup/communication.js";
 describe("storage tools export/import", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    globalThis.chrome.tabs.query.mockResolvedValue([
-      { url: "https://example.com" },
-    ]);
+    globalThis.chrome = {
+      tabs: {
+        query: jest.fn().mockResolvedValue([
+          { url: "https://example.com" },
+        ]),
+      },
+    };
+  });
+
+  afterEach(() => {
+    delete globalThis.chrome;
   });
 
   test("exportLocalStorage triggers download", async () => {

--- a/tests/unit/tools.test.js
+++ b/tests/unit/tools.test.js
@@ -22,6 +22,10 @@ describe("tools export/import", () => {
     };
   });
 
+  afterEach(() => {
+    delete globalThis.chrome;
+  });
+
   test("exportLocalStorage triggers download", async () => {
     send.mockResolvedValue({ foo: "bar" });
 


### PR DESCRIPTION
## Summary
- ensure tests clean up `globalThis.chrome`
- reset chrome mock in each test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844511dfe008320b1cd77d9a296bf9a