### PR TITLE
Fix console spam on extension startup

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -74,7 +74,9 @@
 
   // Message Handler
   chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
-    console.log("[js-cheater] Received message:", msg);
+    if (msg.cmd !== "test") {
+      console.log("[js-cheater] Received message:", msg);
+    }
 
     switch (msg.cmd) {
       case "ping":


### PR DESCRIPTION
## Summary
- silence repetitive '[js-cheater] Received message: {cmd: "test"}' logs

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684530d16adc8320a9441b4513165a94