### PR TITLE
Update README Hinweis zu Setup vor e2e-Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ npm run lint         # Prüft den Code-Stil mit ESLint und Prettier
 npm run format       # Formatiert den Code mit Prettier
 npm test             # Führt die Unit-Tests mit Jest aus
 npm run test:e2e     # Startet die Playwright-Tests (benötigt installierte Browser)
+# Vor dem Ausführen unbedingt `npm run setup` oder `npx playwright install` ausführen
 ```
 
 - Vor `npm test`, `npm run lint` oder `npm run format` unbedingt einmal `npm install` (oder `npm run setup`) ausführen.


### PR DESCRIPTION
## Summary
- add explicit hint to run Playwright setup before e2e tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684530d7664c8320981ce5ab738fc97a