### PR TITLE
Remove parsePath duplication

### DIFF
--- a/scripts/build-scanner.mjs
+++ b/scripts/build-scanner.mjs
@@ -6,9 +6,29 @@ import { fileURLToPath } from "url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const sourcePath = resolve(__dirname, "../src/scanner-source.js");
+const parsePathFile = resolve(__dirname, "../src/parse-path.js");
 const destPath = resolve(__dirname, "../src/popup/scanner-code.js");
+let code = await readFile(sourcePath, "utf8");
 
-const code = await readFile(sourcePath, "utf8");
+let parsePath = await readFile(parsePathFile, "utf8");
+parsePath = parsePath.replace(/^export\s+/, "").trim();
+// Escape backslashes for embedding in a template literal
+parsePath = parsePath.replace(/\\/g, "\\\\");
+
+// remove import line referencing parse-path.js
+code = code.replace(
+  /^import\s+\{\s*parsePath\s*\}\s+from\s+"\.\/parse-path\.js";\n/m,
+  ""
+);
+
+// insert parsePath function after the utility comment
+const insertMarker = /(^\s*\/\/ Path parsing utility function)/m;
+const indentedParsePath =
+  parsePath
+    .split("\n")
+    .map((l) => "  " + l)
+    .join("\n");
+code = code.replace(insertMarker, `$1\n${indentedParsePath}`);
 
 const escaped = code.replace(/`/g, "\\`").replace(/\$\{/g, "\\${");
 

--- a/src/scanner-source.js
+++ b/src/scanner-source.js
@@ -1,36 +1,9 @@
+import { parsePath } from "./parse-path.js";
 // JS-Cheater Scanner - Füge diesen Code in die Browser-Konsole ein
 (function () {
   console.log("🎮 JS-Cheater Scanner wird geladen...");
 
   // Path parsing utility function
-  function parsePath(path) {
-    const parts = [];
-    const regex = /[^.\\[\\]]+|\\[(.*?)\\]/g;
-    let match;
-    while ((match = regex.exec(path))) {
-      let part = match[0];
-      if (part[0] === "[") {
-        part = match[1];
-        if (
-          (part.startsWith("'") && part.endsWith("'")) ||
-          (part.startsWith('"') && part.endsWith('"'))
-        ) {
-          const quote = part[0];
-          part = part.slice(1, -1);
-          const escRegex = new RegExp("\\\\" + quote, "g");
-          part = part.replace(escRegex, quote);
-        }
-        if (
-          /^\\d+$/.test(part) &&
-          !(match[1].startsWith("'") || match[1].startsWith('"'))
-        ) {
-          part = Number(part);
-        }
-      }
-      parts.push(part);
-    }
-    return parts;
-  }
 
   window.__cheatScanner__ = {
     hits: [],


### PR DESCRIPTION
## Summary
- load `parsePath` from a single source
- embed `parsePath` during scanner build

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684530db3cec8320a546e9832e92f3f0