### PR TITLE
Use stored tab for popup communication

### DIFF
--- a/src/popup/communication.js
+++ b/src/popup/communication.js
@@ -1,17 +1,27 @@
 import { $ } from "./utils.js";
 import { showError } from "./messages.js";
 
+let activeTabId;
+
+export function setActiveTab(tabId) {
+  activeTabId = tabId;
+}
+
 export async function send(cmd, extra = {}) {
   try {
-    const [tab] = await chrome.tabs.query({
-      active: true,
-      lastFocusedWindow: true,
-    });
-    if (!tab) {
-      throw new Error("Kein aktiver Tab gefunden");
+    let tabId = activeTabId;
+    if (!tabId) {
+      const [tab] = await chrome.tabs.query({
+        active: true,
+        lastFocusedWindow: true,
+      });
+      if (!tab) {
+        throw new Error("Kein aktiver Tab gefunden");
+      }
+      tabId = tab.id;
     }
     console.log("Sending message:", { cmd, ...extra });
-    const response = await chrome.tabs.sendMessage(tab.id, { cmd, ...extra });
+    const response = await chrome.tabs.sendMessage(tabId, { cmd, ...extra });
     console.log("Received response:", response);
     return response;
   } catch (error) {

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -1,5 +1,5 @@
 import { $, tryParse } from "./utils.js";
-import { send, checkScannerStatus } from "./communication.js";
+import { send, checkScannerStatus, setActiveTab } from "./communication.js";
 import {
   showSetupMode,
   showScannerMode,
@@ -33,6 +33,9 @@ document.addEventListener("DOMContentLoaded", async () => {
   const valueInput = $("#value");
   const searchTypeSelect = $("#searchType");
   const hitsUl = $("#hits");
+
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (tab) setActiveTab(tab.id);
 
   async function onInject() {
     try {

--- a/tests/unit/communication.test.js
+++ b/tests/unit/communication.test.js
@@ -1,0 +1,33 @@
+/* global describe, test, expect, beforeEach, afterEach */
+import { jest } from "@jest/globals";
+
+describe("communication send", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    globalThis.chrome = {
+      tabs: {
+        query: jest.fn().mockResolvedValue([{ id: 1 }]),
+        sendMessage: jest.fn().mockResolvedValue("ok"),
+      },
+    };
+  });
+
+  afterEach(() => {
+    delete globalThis.chrome;
+  });
+
+  test("queries tab when no id stored", async () => {
+    const { send } = await import("../../src/popup/communication.js");
+    await send("ping");
+    expect(chrome.tabs.query).toHaveBeenCalled();
+    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(1, { cmd: "ping" });
+  });
+
+  test("uses stored tab id when set", async () => {
+    const { send, setActiveTab } = await import("../../src/popup/communication.js");
+    setActiveTab(5);
+    await send("ping");
+    expect(chrome.tabs.query).not.toHaveBeenCalled();
+    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(5, { cmd: "ping" });
+  });
+});


### PR DESCRIPTION
## Summary
- cache the active tab id in `communication.js`
- use this cached id when sending messages
- save the active tab id from the popup on DOMContentLoaded
- add unit tests for the new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684533fd16348320a3113f2865626a52