### PR TITLE
Handle content-script timeouts

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -26,7 +26,7 @@
 
         setTimeout(() => {
           window.removeEventListener("message", cb);
-          resolve({ error: "Timeout" });
+          resolve({ error: "Timeout", timeout: true });
         }, 10000);
       });
     },

--- a/src/popup/communication.js
+++ b/src/popup/communication.js
@@ -23,6 +23,10 @@ export async function send(cmd, extra = {}) {
     console.log("Sending message:", { cmd, ...extra });
     const response = await chrome.tabs.sendMessage(tabId, { cmd, ...extra });
     console.log("Received response:", response);
+    if (response && response.timeout) {
+      showError("❌ Anfrage an Content Script dauerte zu lange.");
+      return null;
+    }
     return response;
   } catch (error) {
     console.error("Kommunikationsfehler:", error);

--- a/tests/unit/communication.test.js
+++ b/tests/unit/communication.test.js
@@ -1,6 +1,10 @@
 /* global describe, test, expect, beforeEach, afterEach */
 import { jest } from "@jest/globals";
 
+jest.mock("../../src/popup/messages.js", () => ({
+  showError: jest.fn(),
+}));
+
 describe("communication send", () => {
   beforeEach(() => {
     jest.resetModules();
@@ -29,5 +33,16 @@ describe("communication send", () => {
     await send("ping");
     expect(chrome.tabs.query).not.toHaveBeenCalled();
     expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(5, { cmd: "ping" });
+  });
+
+  test("shows message on timeout", async () => {
+    const { send } = await import("../../src/popup/communication.js");
+    const { showError } = await import("../../src/popup/messages.js");
+    chrome.tabs.sendMessage.mockResolvedValue({ error: "Timeout", timeout: true });
+    const result = await send("start");
+    expect(showError).toHaveBeenCalledWith(
+      "❌ Anfrage an Content Script dauerte zu lange."
+    );
+    expect(result).toBeNull();
   });
 });

--- a/tests/unit/content.test.js
+++ b/tests/unit/content.test.js
@@ -83,4 +83,16 @@ describe("content message handler", () => {
     listener({ cmd: "nope" }, null, sendResponse);
     expect(sendResponse).toHaveBeenCalledWith({ error: "Unknown command: nope" });
   });
+
+  test("sendCommand timeout returns indicator", async () => {
+    jest.useFakeTimers();
+    window.postMessage = jest.fn();
+    const sendResponse = jest.fn();
+    const ret = listener({ cmd: "start", value: 1 }, null, sendResponse);
+    expect(ret).toBe(true);
+    jest.advanceTimersByTime(10000);
+    await jest.runOnlyPendingTimersAsync();
+    expect(sendResponse).toHaveBeenCalledWith({ error: "Timeout", timeout: true });
+    jest.useRealTimers();
+  });
 });


### PR DESCRIPTION
## Summary
- mark communication timeouts in `sendCommand`
- show a popup error when a timeout occurs
- cover timeout behavior with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684535decf7c8320b51749c0a434aa6d