### PR TITLE
Add popup handler unit tests

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -13,6 +13,13 @@ import { SCANNER_CODE } from "./scanner-code.js";
 let statusInterval;
 let statusFailures = 0;
 
+// Handlers are exported for unit testing. They are assigned once the
+// DOMContentLoaded handler runs and all required DOM elements exist.
+export let onInject;
+export let onStart;
+export let onRefine;
+export let onNewSearch;
+
 export function startConnectionMonitor() {
   clearInterval(statusInterval);
   statusFailures = 0;
@@ -64,7 +71,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   if (tab) setActiveTab(tab.id);
 
-  async function onInject() {
+  async function onInjectHandler() {
     try {
       await navigator.clipboard.writeText(SCANNER_CODE);
       startPolling();
@@ -87,8 +94,9 @@ document.addEventListener("DOMContentLoaded", async () => {
       }
     }
   }
+  onInject = onInjectHandler;
 
-  async function onStart() {
+  async function onStartHandler() {
     const type = searchTypeSelect.value;
     const raw = valueInput.value;
     const val = type === "value" ? tryParse(raw) : raw.trim();
@@ -113,8 +121,9 @@ document.addEventListener("DOMContentLoaded", async () => {
       }
     }
   }
+  onStart = onStartHandler;
 
-  async function onRefine() {
+  async function onRefineHandler() {
     const type = searchTypeSelect.value;
     const raw = valueInput.value;
     const val = type === "value" ? tryParse(raw) : raw.trim();
@@ -138,8 +147,9 @@ document.addEventListener("DOMContentLoaded", async () => {
       }
     }
   }
+  onRefine = onRefineHandler;
 
-  async function onNewSearch() {
+  async function onNewSearchHandler() {
     const type = searchTypeSelect.value;
     const raw = valueInput.value;
     const currentValue = type === "value" ? tryParse(raw) : raw.trim();
@@ -168,6 +178,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       valueInput.focus();
     }
   }
+  onNewSearch = onNewSearchHandler;
 
   // ensure old listeners are removed before adding new ones
   $("#inject").removeEventListener("click", onInject);

--- a/tests/unit/popup.handlers.test.js
+++ b/tests/unit/popup.handlers.test.js
@@ -1,0 +1,119 @@
+/* global describe, test, expect, beforeEach, afterEach */
+import { jest } from "@jest/globals";
+
+// Mock dependencies used by popup handlers
+jest.mock("../../src/popup/communication.js", () => ({
+  send: jest.fn(),
+  checkScannerStatus: jest.fn(),
+  setActiveTab: jest.fn(),
+}));
+
+jest.mock("../../src/popup/ui.js", () => ({
+  showSetupMode: jest.fn(),
+  showScannerMode: jest.fn(),
+  showInitialScanState: jest.fn(),
+  showRefineScanState: jest.fn(),
+  updateList: jest.fn(),
+}));
+
+jest.mock("../../src/popup/messages.js", () => ({
+  showError: jest.fn(),
+}));
+
+let send, showError, showRefineScanState, showInitialScanState, updateList;
+
+let onInject, onStart, onRefine, onNewSearch, startPolling;
+
+beforeEach(async () => {
+  jest.useFakeTimers();
+  jest.resetModules();
+  ({ send } = await import("../../src/popup/communication.js"));
+  ({ showError } = await import("../../src/popup/messages.js"));
+  ({ showRefineScanState, showInitialScanState, updateList } = await import("../../src/popup/ui.js"));
+  document.body.innerHTML = `
+    <input id="value" />
+    <select id="searchType"><option value="value">value</option><option value="name">name</option></select>
+    <div id="initialScanGroup"></div>
+    <div id="refineScanGroup"></div>
+    <ul id="hits"></ul>
+    <button id="inject"></button>
+    <button id="start"></button>
+    <button id="refine"></button>
+    <button id="newSearch"></button>
+    <div id="instructions"></div>
+    <div id="scannerUI"></div>
+    <div id="setupSection"></div>
+  `;
+
+  global.navigator.clipboard = { writeText: jest.fn().mockResolvedValue() };
+  document.execCommand = jest.fn();
+  global.alert = jest.fn();
+  globalThis.chrome = {
+    tabs: { query: jest.fn().mockResolvedValue([{ id: 1 }]) },
+  };
+
+  const popup = await import("../../src/popup/popup.js");
+  jest.spyOn(popup, "startPolling").mockImplementation(jest.fn());
+  startPolling = popup.startPolling;
+
+  const { checkScannerStatus } = await import("../../src/popup/communication.js");
+  checkScannerStatus.mockResolvedValue(false);
+
+  await document.dispatchEvent(new Event("DOMContentLoaded"));
+  await Promise.resolve();
+  ({ onInject, onStart, onRefine, onNewSearch } = popup);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.clearAllMocks();
+  delete globalThis.chrome;
+  delete global.navigator.clipboard;
+  delete document.execCommand;
+});
+
+describe("popup handlers", () => {
+  test("onInject copies code", async () => {
+    await onInject();
+    expect(navigator.clipboard.writeText).toHaveBeenCalled();
+  });
+
+  test("onStart sends start command and switches state", async () => {
+    document.getElementById("value").value = "42";
+    document.getElementById("searchType").value = "value";
+    send.mockResolvedValue(3);
+
+    await onStart();
+    expect(send).toHaveBeenCalledWith("start", { value: 42 });
+    expect(showError).toHaveBeenCalledWith("Scanne...");
+    await Promise.resolve();
+    expect(showError).toHaveBeenCalledWith("✅ 3 Treffer gefunden");
+    expect(showRefineScanState).toHaveBeenCalled();
+    jest.runOnlyPendingTimers();
+    expect(updateList).toHaveBeenCalled();
+  });
+
+  test("onRefine sends refine command", async () => {
+    document.getElementById("value").value = "21";
+    document.getElementById("searchType").value = "value";
+    send.mockResolvedValue(1);
+
+    await onRefine();
+    expect(send).toHaveBeenCalledWith("refine", { value: 21 });
+    await Promise.resolve();
+    expect(showError).toHaveBeenCalledWith("🔬 1 Treffer nach Verfeinerung");
+    jest.runOnlyPendingTimers();
+    expect(updateList).toHaveBeenCalled();
+  });
+
+  test("onNewSearch resets when input empty", async () => {
+    document.getElementById("value").value = "";
+    document.getElementById("searchType").value = "value";
+
+    await onNewSearch();
+    expect(send.mock.calls[0][0]).toBe("start");
+    expect(send.mock.calls[0][1].value).toMatch(/^__RESET_SCAN__/);
+    expect(showInitialScanState).toHaveBeenCalled();
+    expect(document.getElementById("hits").innerHTML).toContain("Erster Scan");
+  });
+});


### PR DESCRIPTION
## Summary
- export popup handlers for testing
- cover popup handlers with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845502fa6508320ab54752b9da23aa3