### PR TITLE
Add comprehensive scanner tests

### DIFF
--- a/tests/unit/scanner.test.js
+++ b/tests/unit/scanner.test.js
@@ -49,3 +49,106 @@ describe("freezeByPath", () => {
     expect(window.gameScore).toBe(2);
   });
 });
+
+describe("scan and refine", () => {
+  beforeEach(() => {
+    window.varA = 9999;
+    window.varB = 9999;
+    delete window.__cheatScanner__;
+
+    const originalConsoleLog = console.log;
+    console.log = jest.fn();
+    eval(SCANNER_CODE);
+    console.log = originalConsoleLog;
+  });
+
+  test("refine reduces hit count", () => {
+    const initial = window.__cheatScanner__.scan(9999);
+    window.varB = 1;
+    const refined = window.__cheatScanner__.refine(9999);
+    expect(refined).toBeLessThan(initial);
+    expect(refined).toBeGreaterThan(0);
+  });
+});
+
+describe("refineByName", () => {
+  beforeEach(() => {
+    window.fooScore = 1;
+    window.barScore = 2;
+    delete window.__cheatScanner__;
+
+    const originalConsoleLog = console.log;
+    console.log = jest.fn();
+    eval(SCANNER_CODE);
+    console.log = originalConsoleLog;
+  });
+
+  test("filters hits by name", () => {
+    const count = window.__cheatScanner__.scanByName("score");
+    const refined = window.__cheatScanner__.refineByName("foo");
+    expect(refined).toBeLessThan(count);
+    const paths = window.__cheatScanner__.list().map((h) => h.path);
+    const match = paths.find((p) => p.includes("fooScore"));
+    expect(match).toBeDefined();
+  });
+});
+
+describe("poke and pokeByPath", () => {
+  beforeEach(() => {
+    window.pokeVar = 11;
+    window.nestedObj = { val: 22 };
+    delete window.__cheatScanner__;
+
+    const originalConsoleLog = console.log;
+    console.log = jest.fn();
+    eval(SCANNER_CODE);
+    console.log = originalConsoleLog;
+  });
+
+  test("poke changes value via index", () => {
+    window.__cheatScanner__.scanByName("pokeVar");
+    const ok = window.__cheatScanner__.poke(0, 33);
+    expect(ok).toBe(true);
+    expect(window.pokeVar).toBe(33);
+  });
+
+  test("pokeByPath changes nested value", () => {
+    const res = window.__cheatScanner__.pokeByPath("window.nestedObj.val", 44);
+    expect(res.success).toBe(true);
+    expect(window.nestedObj.val).toBe(44);
+  });
+});
+
+describe("list and helpers", () => {
+  beforeEach(() => {
+    window.listVar = 55;
+    delete window.__cheatScanner__;
+
+    const originalConsoleLog = console.log;
+    console.log = jest.fn();
+    eval(SCANNER_CODE);
+    console.log = originalConsoleLog;
+  });
+
+  test("list returns path/value pairs", () => {
+    window.__cheatScanner__.scanByName("listVar");
+    const list = window.__cheatScanner__.list();
+    const item = list.find((e) => e.path.includes("listVar"));
+    expect(item).toBeDefined();
+    expect(item.value).toBe(55);
+  });
+
+  test("showHits reports when empty", () => {
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    window.__cheatScanner__.hits = [];
+    window.__cheatScanner__.showHits();
+    expect(logSpy).toHaveBeenCalledWith("📭 No hits found");
+    logSpy.mockRestore();
+  });
+
+  test("test returns scanner info", () => {
+    const info = window.__cheatScanner__.test();
+    expect(info.scannerLoaded).toBe(true);
+    expect(info.hitCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- expand `scanner.test.js` with multiple new describe blocks
- test scan/refine cycles and refineByName
- verify poke, pokeByPath, list, showHits and test methods

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845527a397c83209d995f5b483a9747