### PR TITLE
Add tests for utils helpers

### DIFF
--- a/src/popup/utils.js
+++ b/src/popup/utils.js
@@ -24,7 +24,8 @@ export function safeStringify(value) {
   try {
     const json = JSON.stringify(value);
     return json === undefined ? String(value) : json;
-  } catch {
+  } catch (err) {
+    if (/circular/i.test(String(err))) return "[unserializable]";
     try {
       return String(value);
     } catch {

--- a/tests/unit/utils.test.js
+++ b/tests/unit/utils.test.js
@@ -1,5 +1,5 @@
 /* global describe, test, expect */
-import { tryParse } from "../../src/popup/utils.js";
+import { tryParse, escapeHtml, safeStringify } from "../../src/popup/utils.js";
 
 describe("tryParse", () => {
   test("returns parsed object for JSON strings", () => {
@@ -13,5 +13,28 @@ describe("tryParse", () => {
 
   test("returns empty string for empty input", () => {
     expect(tryParse("")).toBe("");
+  });
+});
+
+describe("escapeHtml", () => {
+  test("escapes <, &, and ' characters", () => {
+    expect(escapeHtml("<")).toBe("&lt;");
+    expect(escapeHtml("&")).toBe("&amp;");
+    expect(escapeHtml("'")).toBe("&#39;");
+    expect(escapeHtml("Tom & Jerry <3")).toBe("Tom &amp; Jerry &lt;3");
+  });
+});
+
+describe("safeStringify", () => {
+  test("stringifies objects and primitive values", () => {
+    expect(safeStringify({ a: 1 })).toBe('{"a":1}');
+    expect(safeStringify(42)).toBe("42");
+    expect(safeStringify("foo")).toBe('"foo"');
+  });
+
+  test("returns [unserializable] for circular references", () => {
+    const obj = {};
+    obj.self = obj;
+    expect(safeStringify(obj)).toBe("[unserializable]");
   });
 });


### PR DESCRIPTION
## Summary
- extend utils tests for escapeHtml and safeStringify
- improve safeStringify to detect circular references

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845545b483883209c8956d907a48d47