### PR TITLE
Add util tests and tweak safeStringify

### DIFF
--- a/src/popup/utils.js
+++ b/src/popup/utils.js
@@ -25,10 +25,6 @@ export function safeStringify(value) {
     const json = JSON.stringify(value);
     return json === undefined ? String(value) : json;
   } catch {
-    try {
-      return String(value);
-    } catch {
-      return "[unserializable]";
-    }
+    return "[unserializable]";
   }
 }

--- a/tests/unit/utils.test.js
+++ b/tests/unit/utils.test.js
@@ -1,5 +1,5 @@
 /* global describe, test, expect */
-import { tryParse } from "../../src/popup/utils.js";
+import { tryParse, escapeHtml, safeStringify } from "../../src/popup/utils.js";
 
 describe("tryParse", () => {
   test("returns parsed object for JSON strings", () => {
@@ -13,5 +13,26 @@ describe("tryParse", () => {
 
   test("returns empty string for empty input", () => {
     expect(tryParse("")).toBe("");
+  });
+});
+
+describe("escapeHtml", () => {
+  test("escapes special characters", () => {
+    expect(escapeHtml("<>&'\"")).toBe("&lt;&gt;&amp;&#39;&quot;");
+  });
+});
+
+describe("safeStringify", () => {
+  test("handles objects and primitives", () => {
+    expect(safeStringify({ a: 1 })).toBe('{"a":1}');
+    expect(safeStringify(42)).toBe("42");
+    expect(safeStringify("foo")).toBe('"foo"');
+    expect(safeStringify(undefined)).toBe("undefined");
+  });
+
+  test("returns [unserializable] for circular structures", () => {
+    const a = {};
+    a.self = a;
+    expect(safeStringify(a)).toBe("[unserializable]");
   });
 });


### PR DESCRIPTION
## Summary
- extend utils tests for `escapeHtml` and `safeStringify`
- adjust `safeStringify` to return `[unserializable]` when JSON serialization fails

## Testing
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_684553df07488320b4957eec0cc0d7c3