### PR TITLE
Add messages.js unit tests

### DIFF
--- a/tests/unit/messages.test.js
+++ b/tests/unit/messages.test.js
@@ -1,0 +1,37 @@
+/* global describe, test, expect, beforeEach */
+import { showError, showSuccess } from "../../src/popup/messages.js";
+
+describe("messages", () => {
+  let hits;
+  let searchTab;
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <ul id="hits"></ul>
+      <div id="searchTab" class="tab-panel active"></div>
+    `;
+    hits = document.getElementById("hits");
+    searchTab = document.getElementById("searchTab");
+  });
+
+  test("showError adds red list item", () => {
+    showError("Fehler");
+    const li = hits.querySelector("li");
+    expect(li.textContent).toBe("Fehler");
+    expect(li.style.color).toBe("rgb(231, 76, 60)");
+  });
+
+  test("showSuccess shows message in active search tab", () => {
+    showSuccess("Erfolg");
+    const li = hits.querySelector("li");
+    expect(li.textContent).toBe("Erfolg");
+    expect(li.style.color).toBe("rgb(39, 174, 96)");
+  });
+
+  test("showSuccess logs message when search tab inactive", () => {
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    searchTab.classList.remove("active");
+    showSuccess("Hallo");
+    expect(logSpy).toHaveBeenCalledWith("✅", "Hallo");
+    logSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- cover message rendering in popup
- check showError red output
- check showSuccess for active and inactive tabs

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845c02d1ddc832098f7efe1aa66319d