### PR TITLE
Fix missing content-script after extension reload

### DIFF
--- a/tests/unit/popup.handlers.test.js
+++ b/tests/unit/popup.handlers.test.js
@@ -50,6 +50,7 @@ beforeEach(async () => {
   global.alert = jest.fn();
   globalThis.chrome = {
     tabs: { query: jest.fn().mockResolvedValue([{ id: 1 }]) },
+    scripting: { executeScript: jest.fn().mockResolvedValue() },
   };
 
   const popup = await import("../../src/popup/popup.js");
@@ -76,6 +77,7 @@ describe("popup handlers", () => {
   test("onInject copies code", async () => {
     await onInject();
     expect(navigator.clipboard.writeText).toHaveBeenCalled();
+    expect(globalThis.chrome.scripting.executeScript).toHaveBeenCalled();
   });
 
   test("onStart sends start command and switches state", async () => {


### PR DESCRIPTION
## Summary
- ensure the content script is injected when pressing **Scanner‑Code kopieren**
- adjust tests for the new injection behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845c00f7c5c83208894e35133aa4874