### PR TITLE
Add quick scanner detect test

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -9,6 +9,7 @@ import {
 } from "./ui.js";
 import { showError } from "./messages.js";
 import { SCANNER_CODE } from "./scanner-code.js";
+import * as popupSelf from "./popup.js";
 
 let statusInterval;
 let statusFailures = 0;
@@ -20,7 +21,7 @@ export let onStart;
 export let onRefine;
 export let onNewSearch;
 
-export function startConnectionMonitor() {
+export let startConnectionMonitor = function startConnectionMonitor() {
   clearInterval(statusInterval);
   statusFailures = 0;
   statusInterval = setInterval(async () => {
@@ -33,7 +34,7 @@ export function startConnectionMonitor() {
       stopConnectionMonitor();
     }
   }, 5000);
-}
+};
 
 export function stopConnectionMonitor() {
   if (statusInterval) {
@@ -52,7 +53,7 @@ export function startPolling() {
       scannerFound = true;
       clearInterval(checkInterval);
       showScannerMode();
-      startConnectionMonitor();
+      popupSelf.startConnectionMonitor();
     }
   }, 500);
   setTimeout(() => {
@@ -196,7 +197,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   const scannerReady = await checkScannerStatus();
   if (scannerReady) {
     showScannerMode();
-    startConnectionMonitor();
+    popupSelf.startConnectionMonitor();
     await updateList();
   } else {
     showSetupMode();

--- a/tests/unit/popup.test.js
+++ b/tests/unit/popup.test.js
@@ -19,11 +19,8 @@ jest.mock("../../src/popup/messages.js", () => ({
   showError: jest.fn(),
 }));
 
-import {
-  startPolling,
-  startConnectionMonitor,
-  stopConnectionMonitor,
-} from "../../src/popup/popup.js";
+import * as popup from "../../src/popup/popup.js";
+const { startPolling, startConnectionMonitor, stopConnectionMonitor } = popup;
 import { checkScannerStatus } from "../../src/popup/communication.js";
 import { showScannerMode, showSetupMode } from "../../src/popup/ui.js";
 import { showError } from "../../src/popup/messages.js";
@@ -54,6 +51,18 @@ describe("startPolling", () => {
     );
     expect(showScannerMode).not.toHaveBeenCalled();
     expect(document.getElementById("instructions").style.display).toBe("block");
+  });
+
+  test("scanner found quickly", async () => {
+    checkScannerStatus.mockResolvedValue(true);
+    const monitorSpy = jest.spyOn(popup, "startConnectionMonitor");
+    startPolling();
+
+    jest.advanceTimersByTime(500);
+    await Promise.resolve();
+
+    expect(showScannerMode).toHaveBeenCalledTimes(1);
+    expect(monitorSpy).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## Summary
- add a test for quick scanner detection
- allow spying on `startConnectionMonitor` by calling through self import

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845c2ecddcc83208ab1b043545eb48f