### PR TITLE
Strip `window.globalThis.` prefix in UI

### DIFF
--- a/src/popup/ui.js
+++ b/src/popup/ui.js
@@ -97,7 +97,8 @@ export function renderHits(list) {
 
   list.forEach((h, i) => {
     const li = document.createElement("li");
-    li.textContent = `[${i}] ${h.path} = ${safeStringify(h.value)}`;
+    const displayPath = h.path.replace(/^window\.globalThis\./, "");
+    li.textContent = `[${i}] ${displayPath} = ${safeStringify(h.value)}`;
     li.onclick = async () => {
       const value = prompt(`Neuer Wert für ${h.path}:`, h.value);
       if (value !== null) {
@@ -121,7 +122,8 @@ export function renderHitsWithSaveButtons(list) {
     const li = document.createElement("li");
     const hitInfo = document.createElement("div");
     hitInfo.className = "hit-info";
-    hitInfo.innerHTML = `[${i}] ${escapeHtml(h.path)} = ${escapeHtml(safeStringify(h.value))}`;
+    const displayPath = h.path.replace(/^window\.globalThis\./, "");
+    hitInfo.innerHTML = `[${i}] ${escapeHtml(displayPath)} = ${escapeHtml(safeStringify(h.value))}`;
 
     const saveBtn = document.createElement("button");
     saveBtn.className = "save-btn";

--- a/tests/unit/ui.test.js
+++ b/tests/unit/ui.test.js
@@ -68,6 +68,20 @@ describe("ui rendering", () => {
     expect(send).toHaveBeenCalledWith("unfreeze", { path: "foo" });
   });
 
+  test("renderHits trims window.globalThis prefix", () => {
+    const list = [{ path: "window.globalThis.foo", value: 1 }];
+    renderHits(list);
+    const li = document.querySelector("#hits li");
+    expect(li.textContent).toBe("[0] foo = 1");
+  });
+
+  test("renderHitsWithSaveButtons trims window.globalThis prefix", () => {
+    const list = [{ path: "window.globalThis.bar", value: 2 }];
+    renderHitsWithSaveButtons(list);
+    const info = document.querySelector("#hits .hit-info");
+    expect(info.innerHTML).toBe("[0] bar = 2");
+  });
+
   test("updateList fetches and displays hits with refine state", async () => {
     send.mockResolvedValue([{ path: "p", value: 1 }]);
     await updateList();


### PR DESCRIPTION
## Summary
- drop the verbose `window.globalThis.` prefix when rendering search results
- test that both render functions trim the prefix

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c48cd284832090e86a3627092ea4