### PR TITLE
Add central debug flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ npm run test:e2e     # Startet die Playwright-Tests (benötigt installierte Brow
 
 - **Build-Schritt:** `npm run build` generiert den String aus `src/scanner-source.js`.
 - **Scanner-Code bearbeiten:** Änderungen in `src/scanner-source.js` erfordern `npm run build`.
+- **Debug-Logs:** Ändere `DEBUG` in `src/debug.js` auf `true`, um zusätzliche Konsolenausgaben zu erhalten.
 - **Testen:** Unit-Tests mit `npm test`, E2E-Tests mit `npm run test:e2e`. Führe zuvor `npm install` oder `npm run setup` aus.
 - **Manuelles Testen:** Die Erweiterung kann weiterhin als entpackte Erweiterung geladen werden (Chrome oder Firefox).
 - **Reload:** Nach Code-Änderungen die Erweiterung in `chrome://extensions/` bzw. `about:debugging` neu laden.

--- a/src/content.js
+++ b/src/content.js
@@ -1,5 +1,6 @@
 (() => {
-  console.log("[js-cheater] Content script loaded (postMessage Mode)");
+  const DEBUG = false;
+  if (DEBUG) console.log("[js-cheater] Content script loaded (postMessage Mode)");
 
   const REQ = "__jsCheaterRequest";
   const RES = "__jsCheaterResponse";
@@ -74,7 +75,7 @@
 
   // Message Handler
   chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
-    if (msg.cmd !== "test") {
+    if (DEBUG && msg.cmd !== "test") {
       console.log("[js-cheater] Received message:", msg);
     }
 
@@ -84,31 +85,31 @@
         break;
       case "start":
         API.start(msg.value).then((result) => {
-          console.log("[js-cheater] Start result:", result);
+          if (DEBUG) console.log("[js-cheater] Start result:", result);
           sendResponse(result);
         });
         return true;
       case "scanByName":
         API.scanByName(msg.value).then((result) => {
-          console.log("[js-cheater] scanByName result:", result);
+          if (DEBUG) console.log("[js-cheater] scanByName result:", result);
           sendResponse(result);
         });
         return true;
       case "refine":
         API.refine(msg.value).then((result) => {
-          console.log("[js-cheater] Refine result:", result);
+          if (DEBUG) console.log("[js-cheater] Refine result:", result);
           sendResponse(result);
         });
         return true;
       case "refineByName":
         API.refineByName(msg.value).then((result) => {
-          console.log("[js-cheater] refineByName result:", result);
+          if (DEBUG) console.log("[js-cheater] refineByName result:", result);
           sendResponse(result);
         });
         return true;
       case "list":
         API.list().then((result) => {
-          console.log("[js-cheater] List result:", result);
+          if (DEBUG) console.log("[js-cheater] List result:", result);
           sendResponse(result);
         });
         return true;
@@ -116,25 +117,25 @@
         // Check if it's a path-based poke (for favorites) or index-based poke (for search results)
         if (msg.path) {
           API.pokeByPath(msg.path, msg.value).then((result) => {
-            console.log("[js-cheater] PokeByPath result:", result);
+            if (DEBUG) console.log("[js-cheater] PokeByPath result:", result);
             sendResponse(result);
           });
         } else {
           API.poke(msg.idx, msg.value).then((result) => {
-            console.log("[js-cheater] Poke result:", result);
+            if (DEBUG) console.log("[js-cheater] Poke result:", result);
             sendResponse(result);
           });
         }
         return true;
       case "freeze":
         API.freezeByPath(msg.path, msg.value).then((result) => {
-          console.log("[js-cheater] Freeze result:", result);
+          if (DEBUG) console.log("[js-cheater] Freeze result:", result);
           sendResponse(result);
         });
         return true;
       case "unfreeze":
         API.unfreezeByPath(msg.path).then((result) => {
-          console.log("[js-cheater] Unfreeze result:", result);
+          if (DEBUG) console.log("[js-cheater] Unfreeze result:", result);
           sendResponse(result);
         });
         return true;
@@ -159,7 +160,7 @@
         break;
       case "test":
         API.test().then((result) => {
-          console.log("[js-cheater] Test result:", result);
+          if (DEBUG) console.log("[js-cheater] Test result:", result);
           sendResponse(result);
         });
         return true;

--- a/src/debug.js
+++ b/src/debug.js
@@ -1,0 +1,1 @@
+export const DEBUG = false;

--- a/src/popup/communication.js
+++ b/src/popup/communication.js
@@ -1,5 +1,6 @@
 import { $ } from "./utils.js";
 import { showError } from "./messages.js";
+import { DEBUG } from "../debug.js";
 
 let activeTabId;
 
@@ -20,9 +21,9 @@ export async function send(cmd, extra = {}) {
       }
       tabId = tab.id;
     }
-    console.log("Sending message:", { cmd, ...extra });
+    if (DEBUG) console.log("Sending message:", { cmd, ...extra });
     const response = await chrome.tabs.sendMessage(tabId, { cmd, ...extra });
-    console.log("Received response:", response);
+    if (DEBUG) console.log("Received response:", response);
     if (response && response.timeout) {
       showError("❌ Anfrage an Content Script dauerte zu lange.");
       return null;

--- a/src/popup/messages.js
+++ b/src/popup/messages.js
@@ -1,4 +1,5 @@
 import { $, escapeHtml } from "./utils.js";
+import { DEBUG } from "../debug.js";
 
 export function showError(message) {
   const hitsUl = $("#hits");
@@ -11,6 +12,6 @@ export function showSuccess(message) {
   if (activeTab && activeTab.id === "searchTab") {
     hitsUl.innerHTML = `<li style='color: #27ae60;'>${escapeHtml(message)}</li>`;
   } else {
-    console.log("✅", message);
+    if (DEBUG) console.log("✅", message);
   }
 }

--- a/src/scanner-source.js
+++ b/src/scanner-source.js
@@ -1,7 +1,8 @@
 import { parsePath } from "./parse-path.js";
 // JS-Cheater Scanner - Füge diesen Code in die Browser-Konsole ein
 (function () {
-  console.log("🎮 JS-Cheater Scanner wird geladen...");
+  const DEBUG = window.DEBUG || false;
+  if (DEBUG) console.log("🎮 JS-Cheater Scanner wird geladen...");
 
   // Path parsing utility function
 
@@ -98,10 +99,10 @@ import { parsePath } from "./parse-path.js";
     },
 
     scan: function (value) {
-      console.log("🔍 Scanning for:", value, "type:", typeof value);
+      if (DEBUG) console.log("🔍 Scanning for:", value, "type:", typeof value);
       this.hits = this.findAll(window, (v) => v === value);
-      console.log("✅ Found hits:", this.hits.length);
-      if (this.hits.length > 0) {
+      if (DEBUG) console.log("✅ Found hits:", this.hits.length);
+      if (DEBUG && this.hits.length > 0) {
         console.log("📍 First few hits:", this.hits.slice(0, 5));
       }
       return this.hits.length;
@@ -116,12 +117,12 @@ import { parsePath } from "./parse-path.js";
           return false;
         }
       });
-      console.log(`🔬 Refined from ${oldCount} to ${this.hits.length} hits`);
+      if (DEBUG) console.log(`🔬 Refined from ${oldCount} to ${this.hits.length} hits`);
       return this.hits.length;
     },
 
     scanByName: function (name) {
-      console.log("🔍 Scanning by name:", name);
+      if (DEBUG) console.log("🔍 Scanning by name:", name);
       this.hits = this.findAll(window, (val, k) => {
         // match key substring and ensure the value is primitive
         const matches = k.toLowerCase().includes(name.toLowerCase());
@@ -130,8 +131,8 @@ import { parsePath } from "./parse-path.js";
           (typeof val !== "object" && typeof val !== "function");
         return matches && isPrimitive;
       });
-      console.log("✅ Found hits:", this.hits.length);
-      if (this.hits.length > 0) {
+      if (DEBUG) console.log("✅ Found hits:", this.hits.length);
+      if (DEBUG && this.hits.length > 0) {
         console.log("📍 First few hits:", this.hits.slice(0, 5));
       }
       return this.hits.length;
@@ -153,9 +154,10 @@ import { parsePath } from "./parse-path.js";
           (typeof val !== "object" && typeof val !== "function");
         return matches && isPrimitive;
       });
-      console.log(
-        `🔬 Refined by name from ${oldCount} to ${this.hits.length} hits`
-      );
+      if (DEBUG)
+        console.log(
+          `🔬 Refined by name from ${oldCount} to ${this.hits.length} hits`
+        );
       return this.hits.length;
     },
 
@@ -171,7 +173,7 @@ import { parsePath } from "./parse-path.js";
           typeof rawValue === "function" ? rawValue.toString() : rawValue;
         return { path, value };
       });
-      console.table(result);
+      if (DEBUG) console.table(result);
       return result;
     },
 
@@ -183,21 +185,21 @@ import { parsePath } from "./parse-path.js";
       }
       const oldVal = hit.obj[hit.key];
       hit.obj[hit.key] = value;
-      console.log(`🎯 Changed ${hit.path}: ${oldVal} → ${value}`);
+      if (DEBUG) console.log(`🎯 Changed ${hit.path}: ${oldVal} → ${value}`);
       return true;
     },
 
     pokeByPath: function (path, value) {
       try {
-        console.log("🎯 pokeByPath called with:", path, "value:", value);
+        if (DEBUG) console.log("🎯 pokeByPath called with:", path, "value:", value);
 
         const pathParts = parsePath(path);
-        console.log("🎯 Path parts:", pathParts);
+        if (DEBUG) console.log("🎯 Path parts:", pathParts);
 
         let obj = window;
 
         for (let i = 1; i < pathParts.length - 1; i++) {
-          console.log("🎯 Navigating to: " + pathParts[i]);
+          if (DEBUG) console.log("🎯 Navigating to: " + pathParts[i]);
           obj = obj[pathParts[i]];
           if (obj === undefined || obj === null) {
             console.error("❌ Path not found at:", pathParts[i]);
@@ -209,9 +211,9 @@ import { parsePath } from "./parse-path.js";
         }
 
         const key = pathParts[pathParts.length - 1];
-        console.log("🎯 Final key:", key);
-        console.log("🎯 Target object:", obj);
-        console.log("🎯 Current value:", obj[key]);
+        if (DEBUG) console.log("🎯 Final key:", key);
+        if (DEBUG) console.log("🎯 Target object:", obj);
+        if (DEBUG) console.log("🎯 Current value:", obj[key]);
 
         if (!(key in obj)) {
           console.error("❌ Property not found:", key);
@@ -221,10 +223,11 @@ import { parsePath } from "./parse-path.js";
         const oldVal = obj[key];
         obj[key] = value;
 
-        console.log(
-          "🎯 Successfully changed " + path + ": " + oldVal + " → " + value
-        );
-        console.log("🎯 Verification - new value:", obj[key]);
+        if (DEBUG)
+          console.log(
+            "🎯 Successfully changed " + path + ": " + oldVal + " → " + value
+          );
+        if (DEBUG) console.log("🎯 Verification - new value:", obj[key]);
 
         return { success: true, oldValue: oldVal, newValue: value };
       } catch (error) {
@@ -260,7 +263,7 @@ import { parsePath } from "./parse-path.js";
         }, 100);
 
         this.frozen.set(path, { timer });
-        console.log("❄️ Frozen", path, "to", value);
+        if (DEBUG) console.log("❄️ Frozen", path, "to", value);
         return { success: true };
       } catch (error) {
         console.error("freezeByPath error", error);
@@ -273,7 +276,7 @@ import { parsePath } from "./parse-path.js";
       if (entry) {
         clearInterval(entry.timer);
         this.frozen.delete(path);
-        console.log("🧊 Unfrozen", path);
+        if (DEBUG) console.log("🧊 Unfrozen", path);
         return { success: true };
       }
       return { success: false, error: "Not frozen" };
@@ -281,12 +284,13 @@ import { parsePath } from "./parse-path.js";
 
     showHits: function () {
       if (this.hits.length === 0) {
-        console.log("📭 No hits found");
+        if (DEBUG) console.log("📭 No hits found");
         return;
       }
-      console.log(`📋 ${this.hits.length} hits:`);
+      if (DEBUG) console.log(`📋 ${this.hits.length} hits:`);
       this.hits.forEach((hit, i) => {
-        console.log(`[${i}] ${hit.path} = ${JSON.stringify(hit.obj[hit.key])}`);
+        if (DEBUG)
+          console.log(`[${i}] ${hit.path} = ${JSON.stringify(hit.obj[hit.key])}`);
       });
     },
 
@@ -357,7 +361,8 @@ import { parsePath } from "./parse-path.js";
     false
   );
 
-  console.log(
-    "🎮 JS-Cheater Scanner bereit! Verwende window.__cheatScanner__.scan(wert)"
-  );
+  if (DEBUG)
+    console.log(
+      "🎮 JS-Cheater Scanner bereit! Verwende window.__cheatScanner__.scan(wert)"
+    );
 })();

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,5 +1,6 @@
 // src/service-worker.js
 // js-cheater – Background Service-Worker (Manifest V3)
+import { DEBUG } from "./debug.js";
 
 // Sets the side panel to open automatically when clicking the action icon.
 // Firefox does not support this API, so we guard it.
@@ -26,9 +27,9 @@ async function openPanel(tabId) {
 // Called when the extension is first installed or updated
 chrome.runtime.onInstalled.addListener(({ reason, previousVersion }) => {
   if (reason === "install") {
-    console.log("[js-cheater] Extension installed 🚀");
+    if (DEBUG) console.log("[js-cheater] Extension installed 🚀");
   } else if (reason === "update") {
-    console.log(`[js-cheater] Updated from ${previousVersion}`);
+    if (DEBUG) console.log(`[js-cheater] Updated from ${previousVersion}`);
   }
   enableSidePanelOnClick();
 });
@@ -41,7 +42,7 @@ chrome.action.onClicked.addListener(async (tab) => {
   if (!tab.id) return;
   try {
     await openPanel(tab.id);
-    console.log("[js-cheater] Side panel opened successfully");
+    if (DEBUG) console.log("[js-cheater] Side panel opened successfully");
   } catch (error) {
     console.error("[js-cheater] Failed to open side panel:", error);
   }

--- a/tests/unit/messages.test.js
+++ b/tests/unit/messages.test.js
@@ -1,4 +1,5 @@
 /* global describe, test, expect, beforeEach */
+jest.mock("../../src/debug.js", () => ({ DEBUG: true }));
 import { showError, showSuccess } from "../../src/popup/messages.js";
 
 describe("messages", () => {

--- a/tests/unit/scanner.test.js
+++ b/tests/unit/scanner.test.js
@@ -124,10 +124,16 @@ describe("list and helpers", () => {
     window.listVar = 55;
     delete window.__cheatScanner__;
 
+    window.DEBUG = true;
+
     const originalConsoleLog = console.log;
     console.log = jest.fn();
     eval(SCANNER_CODE);
     console.log = originalConsoleLog;
+  });
+
+  afterEach(() => {
+    delete window.DEBUG;
   });
 
   test("list returns path/value pairs", () => {


### PR DESCRIPTION
## Summary
- add `DEBUG` flag module
- wrap console logging behind flag in popup modules and service worker
- allow scanner code to read `window.DEBUG`
- update unit tests for debug flag
- document flag in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845c7f954a88320b14d10b847d59005