### PR TITLE
Strip window prefixes and add tooltips

### DIFF
--- a/src/popup/ui.js
+++ b/src/popup/ui.js
@@ -12,6 +12,10 @@ import { showError } from "./messages.js";
 let favoritesListenerAdded = false;
 let toolsListenerAdded = false;
 
+function shortenPath(path) {
+  return path.replace(/^(?:window\.globalThis\.|window\.)/, "");
+}
+
 export function initTabs() {
   const tabButtons = document.querySelectorAll(".tab-button");
   const tabPanels = document.querySelectorAll(".tab-panel");
@@ -97,7 +101,9 @@ export function renderHits(list) {
 
   list.forEach((h, i) => {
     const li = document.createElement("li");
-    li.textContent = `[${i}] ${h.path} = ${safeStringify(h.value)}`;
+    const displayPath = shortenPath(h.path);
+    li.textContent = `[${i}] ${displayPath} = ${safeStringify(h.value)}`;
+    li.title = h.path;
     li.onclick = async () => {
       const value = prompt(`Neuer Wert für ${h.path}:`, h.value);
       if (value !== null) {
@@ -121,7 +127,9 @@ export function renderHitsWithSaveButtons(list) {
     const li = document.createElement("li");
     const hitInfo = document.createElement("div");
     hitInfo.className = "hit-info";
-    hitInfo.innerHTML = `[${i}] ${escapeHtml(h.path)} = ${escapeHtml(safeStringify(h.value))}`;
+    const displayPath = shortenPath(h.path);
+    hitInfo.innerHTML = `[${i}] ${escapeHtml(displayPath)} = ${escapeHtml(safeStringify(h.value))}`;
+    hitInfo.title = h.path;
 
     const saveBtn = document.createElement("button");
     saveBtn.className = "save-btn";

--- a/tests/unit/ui.test.js
+++ b/tests/unit/ui.test.js
@@ -68,6 +68,32 @@ describe("ui rendering", () => {
     expect(send).toHaveBeenCalledWith("unfreeze", { path: "foo" });
   });
 
+  test("renderHits trims window prefixes and sets tooltip", () => {
+    const list = [
+      { path: "window.globalThis.foo", value: 1 },
+      { path: "window.bar", value: 2 },
+    ];
+    renderHits(list);
+    const items = document.querySelectorAll("#hits li");
+    expect(items[0].textContent).toBe("[0] foo = 1");
+    expect(items[0].title).toBe("window.globalThis.foo");
+    expect(items[1].textContent).toBe("[1] bar = 2");
+    expect(items[1].title).toBe("window.bar");
+  });
+
+  test("renderHitsWithSaveButtons trims window prefixes and sets tooltip", () => {
+    const list = [
+      { path: "window.globalThis.baz", value: 3 },
+      { path: "window.qux", value: 4 },
+    ];
+    renderHitsWithSaveButtons(list);
+    const infos = document.querySelectorAll("#hits .hit-info");
+    expect(infos[0].innerHTML).toBe("[0] baz = 3");
+    expect(infos[0].title).toBe("window.globalThis.baz");
+    expect(infos[1].innerHTML).toBe("[1] qux = 4");
+    expect(infos[1].title).toBe("window.qux");
+  });
+
   test("updateList fetches and displays hits with refine state", async () => {
     send.mockResolvedValue([{ path: "p", value: 1 }]);
     await updateList();


### PR DESCRIPTION
## Summary
- shorten displayed paths by removing `window` or `window.globalThis` prefixes
- show the full variable path in a tooltip on hits
- update unit tests for new rendering behaviour

## Testing
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c48cd284832090e86a3627092ea4