### PR TITLE
Add additional parsePath tests

### DIFF
--- a/tests/unit/favorites.test.js
+++ b/tests/unit/favorites.test.js
@@ -23,6 +23,19 @@ describe("parsePath", () => {
   test("handles escaped quotes inside brackets", () => {
     expect(parsePath("foo['ba\\'r']")).toEqual(["foo", "ba'r"]);
   });
+
+  test("parses mixed dot and bracket notation", () => {
+    expect(parsePath("foo['bar'].baz[0]")).toEqual(["foo", "bar", "baz", 0]);
+  });
+
+  test("handles escaped double quotes inside brackets", () => {
+    expect(parsePath('foo["ba\\"z"].qux')).toEqual(["foo", 'ba"z', "qux"]);
+  });
+
+  test("handles invalid or empty input gracefully", () => {
+    expect(parsePath("")).toEqual([]);
+    expect(parsePath("foo.bar.")).toEqual(["foo", "bar"]);
+  });
 });
 
 describe("loadFavorites", () => {


### PR DESCRIPTION
## Summary
- cover mixed notation, escaped quotes and invalid input for parsePath

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845ce54015c8320907c52514defa46c