### PR TITLE
Add text-secondary class for theme support

### DIFF
--- a/src/popup/communication.js
+++ b/src/popup/communication.js
@@ -48,7 +48,7 @@ export async function checkScannerStatus() {
     if (result && result.scannerLoaded) {
       return true;
     }
-  } catch (e) {
+  } catch {
     // Scanner nicht verfügbar
   }
   return false;

--- a/src/popup/favorites.js
+++ b/src/popup/favorites.js
@@ -205,7 +205,7 @@ export async function loadFavorites() {
           (fav) => `
         <tr>
           <td class="favorite-name" data-id="${fav.id}" title="${escapeHtml(fav.path)}" style="max-width: 80px; overflow: hidden; text-overflow: ellipsis; cursor: pointer;">${escapeHtml(fav.name)}</td>
-          <td style="font-weight: bold; color: #2c3e50;">${escapeHtml(JSON.stringify(fav.value))}</td>
+          <td style="font-weight: bold;">${escapeHtml(JSON.stringify(fav.value))}</td>
           <td><input type="text" id="newValue_${fav.id}" placeholder="Neuer Wert..." value="${inputs[fav.id] || ""}" /></td>
           <td>
             <div class="action-buttons">

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -9,6 +9,11 @@
         box-sizing: border-box;
       }
 
+      /* Text colors */
+      .text-secondary {
+        color: #666;
+      }
+
       /* Tab Navigation */
       .tab-nav {
         display: flex;
@@ -232,6 +237,9 @@
         body {
           background: #1e1e1e;
           color: #f0f0f0;
+        }
+        .text-secondary {
+          color: #ccc;
         }
         .tab-nav {
           background: #2b2b2b;

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -10,7 +10,7 @@
     <div id="setupSection">
       <div style="padding: 12px">
         <h3>🎮 JS-Cheater Setup</h3>
-        <p style="font-size: 12px; color: #666; margin-bottom: 15px">
+        <p class="text-secondary" style="font-size: 12px; margin-bottom: 15px">
           Zuerst muss der Scanner-Code in die Browser-Konsole geladen werden.
         </p>
 
@@ -118,7 +118,6 @@
               style="
                 margin: 0 0 8px 0;
                 font-size: 14px;
-                color: #333;
                 font-weight: 600;
                 border-bottom: 1px solid #e0e0e0;
                 padding-bottom: 4px;

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -193,7 +193,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       await send("start", { value: "__RESET_SCAN__" + Math.random() });
       showInitialScanState();
       hitsUl.innerHTML =
-        "<li style='color: #666;'>Gib einen Wert ein und klicke 'Erster Scan'</li>";
+        "<li class='text-secondary'>Gib einen Wert ein und klicke 'Erster Scan'</li>";
       valueInput.focus();
     }
   }

--- a/src/popup/storage-utils.js
+++ b/src/popup/storage-utils.js
@@ -2,7 +2,7 @@ export function loadFromStorage(key) {
   try {
     const item = localStorage.getItem(key);
     return item ? JSON.parse(item) : {};
-  } catch (e) {
+  } catch {
     return {};
   }
 }
@@ -10,7 +10,7 @@ export function loadFromStorage(key) {
 export function saveToStorage(key, obj) {
   try {
     localStorage.setItem(key, JSON.stringify(obj));
-  } catch (e) {
-    console.error('Failed to save to storage:', e);
+  } catch {
+    console.error('Failed to save to storage');
   }
 }

--- a/src/popup/ui.js
+++ b/src/popup/ui.js
@@ -53,7 +53,7 @@ export function showScannerMode() {
   showError("✅ Scanner erfolgreich geladen!");
   setTimeout(() => {
     $("#hits").innerHTML =
-      "<li style='color: #666;'>Gib einen Wert ein und klicke 'Erster Scan'</li>";
+      "<li class='text-secondary'>Gib einen Wert ein und klicke 'Erster Scan'</li>";
   }, 2000);
   setTimeout(() => $("#value")?.focus(), 100);
   showInitialScanState();
@@ -91,7 +91,7 @@ export function renderHits(list) {
   const hitsUl = $("#hits");
   hitsUl.textContent = "";
   if (!list || list.length === 0) {
-    hitsUl.innerHTML = "<li style='color: #666;'>Keine Treffer gefunden</li>";
+    hitsUl.innerHTML = "<li class='text-secondary'>Keine Treffer gefunden</li>";
     return;
   }
 
@@ -114,7 +114,7 @@ export function renderHitsWithSaveButtons(list) {
   const hitsUl = $("#hits");
   hitsUl.textContent = "";
   if (!list || list.length === 0) {
-    hitsUl.innerHTML = "<li style='color: #666;'>Keine Treffer gefunden</li>";
+    hitsUl.innerHTML = "<li class='text-secondary'>Keine Treffer gefunden</li>";
     return;
   }
 


### PR DESCRIPTION
## Summary
- add `.text-secondary` color helpers in popup CSS
- replace inline color styles in popup.html and scripts
- cleanup unused `catch` variables for lint

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68468d4ed648832094d27f500ded1e12