### PR TITLE
Refactor content message dispatcher

### DIFF
--- a/tests/unit/content.test.js
+++ b/tests/unit/content.test.js
@@ -122,6 +122,18 @@ describe("content message handler", () => {
     expect(sendResponse).toHaveBeenCalledWith({ a: "1", b: "2" });
   });
 
+  test("setLocalStorage stores values and responds", () => {
+    const sendResponse = jest.fn();
+    const ret = listener(
+      { cmd: "setLocalStorage", data: { c: "3" } },
+      null,
+      sendResponse
+    );
+    expect(ret).toBeUndefined();
+    expect(localStorage.getItem("c")).toBe("3");
+    expect(sendResponse).toHaveBeenCalledWith({ success: true });
+  });
+
   test("unknown command returns error", () => {
     const sendResponse = jest.fn();
     listener({ cmd: "nope" }, null, sendResponse);


### PR DESCRIPTION
## Summary
- refactor content script message handling to use a command map
- expose generic dispatcher logic
- add unit test for `setLocalStorage` command

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846a69cdafc832096a6d514dcde66c6