### PR TITLE
Add Firefox Manifest V2 variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Viele Spiele liefern strenge CSP‑Header. Daher wird der Scanner nicht automati
    - Chrome → `chrome://extensions/`
    - Firefox → `about:debugging#/runtime/this-firefox`
 5. Entwicklermodus aktivieren → **Entpackte Erweiterung laden** → Projektordner wählen
-6. **Nur Firefox:** In `about:config` die Flags `extensions.manifestV3.enabled` und `extensions.backgroundServiceWorker.enabled` auf `true` setzen und Firefox neu starten.
+6. **Nur Firefox:** Die Datei `manifest.firefox.json` verwenden (z.B. als `manifest.json` kopieren) – keine `about:config`‑Flags nötig.
 7. 🎮 GamePad‑Icon erscheint in der Toolbar
 8. Chrome meldet beim Laden möglicherweise `Unrecognized manifest key 'sidebar_action'`. Diese Warnung ist harmlos, da das Feld nur von Firefox genutzt wird.
 

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -1,0 +1,50 @@
+{
+  "name": "js-cheater",
+  "description": "Cheat-Engine-ähnlicher Scanner für Browser-RPGs",
+  "version": "0.1.0",
+  "manifest_version": 2,
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "js-cheater@example.com",
+      "strict_min_version": "109.0"
+    }
+  },
+  "icons": {
+    "16": "icons/icon128.png",
+    "32": "icons/icon128.png",
+    "48": "icons/icon128.png",
+    "128": "icons/icon128.png"
+  },
+  "permissions": ["activeTab", "storage", "tabs", "<all_urls>"],
+  "background": {
+    "scripts": ["src/background.js"],
+    "persistent": false
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["src/content.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "browser_action": {
+    "default_title": "Aktiviere JS-Cheater für diese Site",
+    "default_icon": {
+      "16": "icons/icon128.png",
+      "32": "icons/icon128.png",
+      "48": "icons/icon128.png",
+      "128": "icons/icon128.png"
+    }
+  },
+  "sidebar_action": {
+    "default_title": "JS-Cheater",
+    "default_panel": "src/popup/popup.html",
+    "default_icon": {
+      "16": "icons/icon128.png",
+      "32": "icons/icon128.png",
+      "48": "icons/icon128.png",
+      "128": "icons/icon128.png"
+    }
+  },
+  "web_accessible_resources": ["src/content.js"]
+}

--- a/src/background.js
+++ b/src/background.js
@@ -1,0 +1,58 @@
+// src/background.js
+// js-cheater – Hintergrundskript für Firefox (Manifest V2)
+
+const DEBUG = false;
+
+// Sets the side panel to open automatically when clicking the action icon.
+// Firefox does not support this API, so we guard it.
+function enableSidePanelOnClick() {
+  if (chrome.sidePanel?.setPanelBehavior) {
+    chrome.sidePanel
+      .setPanelBehavior({ openPanelOnActionClick: true })
+      .catch((error) =>
+        console.error("[js-cheater] Side panel setup error:", error)
+      );
+  }
+}
+
+// Opens the extension UI in Chrome's side panel or Firefox's sidebar
+async function openPanel(tabId) {
+  if (chrome.sidePanel?.open) {
+    return chrome.sidePanel.open({ tabId });
+  }
+  if (chrome.sidebarAction?.open) {
+    return chrome.sidebarAction.open();
+  }
+}
+
+// Called when the extension is first installed or updated
+chrome.runtime.onInstalled.addListener(({ reason, previousVersion }) => {
+  if (reason === "install") {
+    if (DEBUG) console.log("[js-cheater] Extension installed 🚀");
+  } else if (reason === "update") {
+    if (DEBUG) console.log(`[js-cheater] Updated from ${previousVersion}`);
+  }
+  enableSidePanelOnClick();
+});
+
+// Ensure side panel behavior is set when the background script starts
+enableSidePanelOnClick();
+
+// Action icon click handler - opens side panel or sidebar
+const action = chrome.action ?? chrome.browserAction;
+action.onClicked.addListener(async (tab) => {
+  if (!tab.id) return;
+  try {
+    await openPanel(tab.id);
+    if (DEBUG) console.log("[js-cheater] Side panel opened successfully");
+  } catch (error) {
+    console.error("[js-cheater] Failed to open side panel:", error);
+  }
+});
+
+// Message router (optional; currently just a placeholder)
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === "ping") sendResponse("pong");
+  // Important: return true if the response is sent asynchronously
+  return false;
+});

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -117,10 +117,26 @@ document.addEventListener("DOMContentLoaded", async () => {
         currentWindow: true,
       });
       if (currTab) {
-        await chrome.scripting.executeScript({
-          target: { tabId: currTab.id },
-          files: ["src/content.js"],
-        });
+        if (chrome.scripting?.executeScript) {
+          await chrome.scripting.executeScript({
+            target: { tabId: currTab.id },
+            files: ["src/content.js"],
+          });
+        } else if (chrome.tabs?.executeScript) {
+          await new Promise((resolve, reject) => {
+            chrome.tabs.executeScript(
+              currTab.id,
+              { file: "src/content.js" },
+              () => {
+                if (chrome.runtime.lastError) {
+                  reject(chrome.runtime.lastError);
+                } else {
+                  resolve();
+                }
+              }
+            );
+          });
+        }
       }
     } catch (err) {
       console.error("Content-script injection failed", err);


### PR DESCRIPTION
## Summary
- add `manifest.firefox.json` for a Firefox-compatible Manifest V2 build
- provide new `src/background.js` to open the sidebar and handle action clicks
- inject content script in Firefox via `tabs.executeScript` fallback
- document Firefox usage in README

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688dc5cb82f48320bc1b650bf7ca87eb