### PR TITLE
Add build pipeline for Manifest V2 and V3 packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,14 @@ Viele Spiele liefern strenge CSP‑Header. Daher wird der Scanner nicht automati
    ```
 
 3. `npm run build`   # generiert src/popup/scanner-code.js
-4. Erweiterungsseite öffnen
+4. `npm run build:extensions`   # erstellt dist/mv2 und dist/mv3 als ladbare Pakete
+5. Erweiterungsseite öffnen
    - Chrome → `chrome://extensions/`
    - Firefox → `about:debugging#/runtime/this-firefox`
-5. Entwicklermodus aktivieren → **Entpackte Erweiterung laden** → Projektordner wählen
-6. **Nur Firefox:** In `about:config` die Flags `extensions.manifestV3.enabled` und `extensions.backgroundServiceWorker.enabled` auf `true` setzen und Firefox neu starten.
-7. 🎮 GamePad‑Icon erscheint in der Toolbar
-8. Chrome meldet beim Laden möglicherweise `Unrecognized manifest key 'sidebar_action'`. Diese Warnung ist harmlos, da das Feld nur von Firefox genutzt wird.
+6. Entwicklermodus aktivieren → **Entpackte Erweiterung laden** → Projektordner wählen
+7. **Nur Firefox:** In `about:config` die Flags `extensions.manifestV3.enabled` und `extensions.backgroundServiceWorker.enabled` auf `true` setzen und Firefox neu starten.
+8. 🎮 GamePad‑Icon erscheint in der Toolbar
+9. Chrome meldet beim Laden möglicherweise `Unrecognized manifest key 'sidebar_action'`. Diese Warnung ist harmlos, da das Feld nur von Firefox genutzt wird.
 
 ## Schnellstart
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "lint": "eslint src/**/*.js",
     "format": "prettier --write .",
     "build": "node scripts/build-scanner.mjs",
+    "build:extensions": "node scripts/build-extensions.mjs",
     "test": "npm run build && jest",
     "test:unit": "jest",
     "test:e2e": "npm run build && playwright test",

--- a/scripts/build-extensions.mjs
+++ b/scripts/build-extensions.mjs
@@ -1,0 +1,145 @@
+/* global console */
+import { dirname, resolve, basename } from "path";
+import { fileURLToPath } from "url";
+import {
+  cp,
+  mkdir,
+  rm,
+  readFile,
+  writeFile,
+  copyFile,
+  stat,
+} from "fs/promises";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__dirname, "..");
+const distDir = resolve(projectRoot, "dist");
+const manifestPath = resolve(projectRoot, "manifest.json");
+const debugPath = resolve(projectRoot, "src/debug.js");
+const mv2TemplatePath = resolve(__dirname, "templates/background-mv2.js");
+
+async function ensureScannerBuild() {
+  await import("./build-scanner.mjs");
+}
+
+async function resetDist() {
+  await rm(distDir, { recursive: true, force: true });
+  await mkdir(distDir, { recursive: true });
+}
+
+async function copyOptionalFile(source, destinationDir) {
+  try {
+    await copyFile(source, resolve(destinationDir, basename(source)));
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+}
+
+async function copyDirectory(source, destination) {
+  try {
+    const stats = await stat(source);
+    if (!stats.isDirectory()) return;
+    await cp(source, destination, { recursive: true });
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+}
+
+async function writeManifest(targetDir, manifest) {
+  await writeFile(
+    resolve(targetDir, "manifest.json"),
+    JSON.stringify(manifest, null, 2)
+  );
+}
+
+function transformToMv2Manifest(baseManifest) {
+  const manifest = JSON.parse(JSON.stringify(baseManifest));
+  manifest.manifest_version = 2;
+
+  if (manifest.action) {
+    manifest.browser_action = manifest.action;
+    delete manifest.action;
+  }
+
+  delete manifest.side_panel;
+
+  if (manifest.permissions) {
+    manifest.permissions = manifest.permissions.filter(
+      (permission) => permission !== "sidePanel" && permission !== "scripting"
+    );
+  }
+
+  if (!Array.isArray(manifest.permissions)) {
+    manifest.permissions = [];
+  }
+
+  if (Array.isArray(manifest.host_permissions)) {
+    manifest.permissions = Array.from(
+      new Set([...manifest.permissions, ...manifest.host_permissions])
+    );
+    delete manifest.host_permissions;
+  }
+
+  manifest.background = {
+    scripts: ["src/background.js"],
+    persistent: false,
+  };
+
+  if (Array.isArray(manifest.web_accessible_resources)) {
+    const resources = manifest.web_accessible_resources.flatMap((entry) => {
+      if (typeof entry === "string") return [entry];
+      if (entry && Array.isArray(entry.resources)) return entry.resources;
+      return [];
+    });
+    if (resources.length > 0) {
+      manifest.web_accessible_resources = Array.from(new Set(resources));
+    } else {
+      delete manifest.web_accessible_resources;
+    }
+  }
+
+  return manifest;
+}
+
+async function buildMv3(manifest) {
+  const targetDir = resolve(distDir, "mv3");
+  await mkdir(targetDir, { recursive: true });
+  await copyDirectory(resolve(projectRoot, "icons"), resolve(targetDir, "icons"));
+  await copyDirectory(resolve(projectRoot, "src"), resolve(targetDir, "src"));
+  await copyOptionalFile(resolve(projectRoot, "favicon.ico"), targetDir);
+  await copyOptionalFile(resolve(projectRoot, "test.html"), targetDir);
+  await writeManifest(targetDir, manifest);
+  console.info("Built MV3 package in dist/mv3");
+}
+
+async function buildMv2(baseManifest, debugValue) {
+  const targetDir = resolve(distDir, "mv2");
+  await mkdir(targetDir, { recursive: true });
+  await copyDirectory(resolve(projectRoot, "icons"), resolve(targetDir, "icons"));
+  await copyDirectory(resolve(projectRoot, "src"), resolve(targetDir, "src"));
+  await copyOptionalFile(resolve(projectRoot, "favicon.ico"), targetDir);
+  await copyOptionalFile(resolve(projectRoot, "test.html"), targetDir);
+
+  const manifest = transformToMv2Manifest(baseManifest);
+  await writeManifest(targetDir, manifest);
+
+  const template = await readFile(mv2TemplatePath, "utf8");
+  const backgroundCode = template.replace(/__DEBUG_VALUE__/g, debugValue);
+  await writeFile(resolve(targetDir, "src/background.js"), backgroundCode);
+  console.info("Built MV2 package in dist/mv2");
+}
+
+async function main() {
+  await ensureScannerBuild();
+  await resetDist();
+
+  const baseManifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  const debugSource = await readFile(debugPath, "utf8");
+  const debugMatch = debugSource.match(/DEBUG\s*=\s*([^;]+);/);
+  const debugValue = debugMatch ? debugMatch[1].trim() : "false";
+
+  await buildMv3(baseManifest);
+  await buildMv2(baseManifest, debugValue);
+}
+
+await main();

--- a/scripts/templates/background-mv2.js
+++ b/scripts/templates/background-mv2.js
@@ -1,0 +1,53 @@
+/* global chrome */
+
+const DEBUG = __DEBUG_VALUE__;
+
+function enableSidePanelOnClick() {
+  if (chrome.sidePanel?.setPanelBehavior) {
+    chrome.sidePanel
+      .setPanelBehavior({ openPanelOnActionClick: true })
+      .catch((error) =>
+        console.error("[js-cheater] Side panel setup error:", error)
+      );
+  }
+}
+
+async function openPanel(tabId) {
+  if (chrome.sidePanel?.open) {
+    return chrome.sidePanel.open({ tabId });
+  }
+  if (chrome.sidebarAction?.open) {
+    return chrome.sidebarAction.open();
+  }
+}
+
+const actionApi = chrome.action ?? chrome.browserAction;
+
+chrome.runtime.onInstalled.addListener(({ reason, previousVersion }) => {
+  if (reason === "install") {
+    if (DEBUG) console.log("[js-cheater] Extension installed 🚀");
+  } else if (reason === "update") {
+    if (DEBUG) console.log(`[js-cheater] Updated from ${previousVersion}`);
+  }
+  enableSidePanelOnClick();
+});
+
+enableSidePanelOnClick();
+
+if (actionApi?.onClicked) {
+  actionApi.onClicked.addListener(async (tab) => {
+    const tabId = tab?.id;
+    if (!tabId && !chrome.sidebarAction?.open) return;
+    try {
+      await openPanel(tabId);
+      if (DEBUG) console.log("[js-cheater] Side panel opened successfully");
+    } catch (error) {
+      console.error("[js-cheater] Failed to open side panel:", error);
+    }
+  });
+}
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === "ping") sendResponse("pong");
+  return false;
+});

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -117,10 +117,16 @@ document.addEventListener("DOMContentLoaded", async () => {
         currentWindow: true,
       });
       if (currTab) {
-        await chrome.scripting.executeScript({
-          target: { tabId: currTab.id },
-          files: ["src/content.js"],
-        });
+        if (chrome.scripting?.executeScript) {
+          await chrome.scripting.executeScript({
+            target: { tabId: currTab.id },
+            files: ["src/content.js"],
+          });
+        } else if (chrome.tabs?.executeScript) {
+          await chrome.tabs.executeScript(currTab.id, {
+            file: "src/content.js",
+          });
+        }
       }
     } catch (err) {
       console.error("Content-script injection failed", err);

--- a/tests/unit/popup.handlers.test.js
+++ b/tests/unit/popup.handlers.test.js
@@ -49,7 +49,10 @@ beforeEach(async () => {
   document.execCommand = jest.fn();
   global.alert = jest.fn();
   globalThis.chrome = {
-    tabs: { query: jest.fn().mockResolvedValue([{ id: 1 }]) },
+    tabs: {
+      query: jest.fn().mockResolvedValue([{ id: 1 }]),
+      executeScript: jest.fn().mockResolvedValue(),
+    },
     scripting: { executeScript: jest.fn().mockResolvedValue() },
   };
 
@@ -78,6 +81,15 @@ describe("popup handlers", () => {
     await onInject();
     expect(navigator.clipboard.writeText).toHaveBeenCalled();
     expect(globalThis.chrome.scripting.executeScript).toHaveBeenCalled();
+  });
+
+  test("onInject falls back to tabs.executeScript", async () => {
+    globalThis.chrome.scripting.executeScript = undefined;
+
+    await onInject();
+    expect(globalThis.chrome.tabs.executeScript).toHaveBeenCalledWith(1, {
+      file: "src/content.js",
+    });
   });
 
   test("onStart sends start command and switches state", async () => {


### PR DESCRIPTION
## Summary
- add a Node-based build pipeline that outputs MV2 and MV3 extension packages and derives the MV2 background script from a shared template
- document the new build command and ensure the popup injector works in both manifest versions, with unit tests covering the fallback path

## Testing
- npm run build:extensions
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68e23888ec8c8320b6c13ee80646407e